### PR TITLE
fix text color for badge, using color variable that server unread badge uses

### DIFF
--- a/components/QuestButton.tsx
+++ b/components/QuestButton.tsx
@@ -60,6 +60,7 @@ export function QuestsCount() {
                             onMouseLeave={onMouseLeave}
                             count={status.enrollable}
                             color={"var(--status-danger)"}
+                            style={{ color: "var(--background-base-lowest)" }}
                         />
                     )}
                 </Tooltip>
@@ -72,6 +73,7 @@ export function QuestsCount() {
                             onMouseLeave={onMouseLeave}
                             count={status.enrolled}
                             color={"var(--status-warning)"}
+                            style={{ color: "var(--background-base-lowest)" }}
                         />
                     )}
                 </Tooltip>
@@ -84,6 +86,7 @@ export function QuestsCount() {
                             onMouseLeave={onMouseLeave}
                             count={status.claimable}
                             color={"var(--status-positive)"}
+                            style={{ color: "var(--background-base-lowest)" }}
                         />
                     )}
                 </Tooltip>
@@ -96,6 +99,7 @@ export function QuestsCount() {
                             onMouseLeave={onMouseLeave}
                             count={status.claimed}
                             color={"var(--blurple-50)"}
+                            style={{ color: "var(--background-base-lowest)" }}
                         />
                     )}
                 </Tooltip>


### PR DESCRIPTION
I was using catppuccin mocha theme in my vencord and i noticed that count badge value is unreadable. i found out that discord servers unread badge uses `var(--background-base-lowest)` so i added it.

I am not aware of plugin development, and also i found no documentation on `<CountBadge ... />` so i just used inline css. 